### PR TITLE
Idea for a `ProdigyEstimator` class

### DIFF
--- a/scikit-prodigy/__init__.py
+++ b/scikit-prodigy/__init__.py
@@ -29,6 +29,14 @@ class ProdigyEstimator:
         texts, labels = zip(*examples)
         self.estimator.partial_fit(texts, labels)
         return self
+    
+    def predict(self, X):
+        """Maybe just mimic the underlying predict method? Nice to have around?"""
+        pass
+
+    def predict_proba(self, X):
+        """Maybe just mimic the underlying predict_proba method? Nice to have around?"""
+        pass
 
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import make_pipeline 

--- a/scikit-prodigy/__init__.py
+++ b/scikit-prodigy/__init__.py
@@ -1,0 +1,22 @@
+class ProdigyEstimator:
+    def __init__(self, estimator, label=None):
+        self.estimator = estimator
+    
+    def __call__(self, examples):
+        probas = self.estimator.predict_proba([ex['text'] for ex in examples])
+        preds = self.estimator.predict([ex['text'] for ex in examples])
+        for prob, pred in zip(probas, preds):
+            yield (float(prob.max()), pred)
+    
+    def fit_from_prodigy(self, dataset):
+        print(dataset)
+    
+    def update(examples):
+        pass
+
+
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import make_pipeline 
+from sklearn.feature_extraction.text import CountVectorizer
+
+pipe = make_pipeline(CountVectorizer(), LogisticRegression())

--- a/scikit-prodigy/__init__.py
+++ b/scikit-prodigy/__init__.py
@@ -1,6 +1,8 @@
 class ProdigyEstimator:
-    def __init__(self, estimator, label=None):
+    def __init__(self, estimator, dataset, label):
         self.estimator = estimator
+        self.dataset = dataset
+        self.label = label
     
     def __call__(self, examples):
         probas = self.estimator.predict_proba([ex['text'] for ex in examples])
@@ -8,15 +10,29 @@ class ProdigyEstimator:
         for prob, pred in zip(probas, preds):
             yield (float(prob.max()), pred)
     
-    def fit_from_prodigy(self, dataset):
-        print(dataset)
+    def fit_from_prodigy(self):
+        """This only works for binary classes now"""
+        db = connect()
+        examples = db.get_dataset_examples(self.dataset)
+        examples = [(ex, ex['answer'] == 'accept') 
+                    for ex in examples 
+                    if ex['answer'] in ['accept', 'reject']]
+        texts, labels = zip(*examples)
+        self.estimator.fit(texts, labels)
+        msg.info(f"Trained scikit-learn pipeline on {len(examples)} examples.")
+        return self
     
     def update(examples):
-        pass
-
+        examples = [(ex, ex['answer'] == 'accept') 
+                    for ex in examples 
+                    if ex['answer'] in ['accept', 'reject']]
+        texts, labels = zip(*examples)
+        self.estimator.partial_fit(texts, labels)
+        return self
 
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import make_pipeline 
 from sklearn.feature_extraction.text import CountVectorizer
 
 pipe = make_pipeline(CountVectorizer(), LogisticRegression())
+est = ProdigyEstimator(pipe, dataset="name", label="pos")


### PR DESCRIPTION
This is just an idea, but we could consider making a Python class that accepts a sklearn pipeline and then acts as a (text) classifier that Prodigy expects. 

A few things make this super interesting. 

1. Scikit-learn is very well understood.
2. Scikit-learn can be use to easily construct pipelines for non-text data, which is super beneficial.
3. Via [embetter](https://koaning.github.io/embetter/), we have _tons_ of pretrained models at our disposal. Not just for text, but also images! 
 
There are a few caveats though.

1. The `update` method could only work if the underlying pipeline implements `partial_fit`. This isn't natively supported by scikit-learn and would require folks to use [scikit-partial](https://github.com/koaning/scikit-partial). 
5. We'd need to figure out a way to deal with binary classes, multiple classes and multi-label scenarios. Scikit-Learn does not assume multi-label. We also need to make sure that a `fit_from_prodigy` method is able to deal with all the edge-cases. 
6. Serialisation is another tough cookie. Especially when you take pretrained tools from [embetter](https://koaning.github.io/embetter/) into account. You might have components that do not save nicely. So we are going to force the user to take care of serialisation. That also means that we'll probably not be able to have a nice `train` command. That's also something the user would need to implement themselves. 